### PR TITLE
Fix: Correct asymptote keys, update README, and improve plotting robu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
 Install the required Python libraries using the following command:
 
 ```bash
-pip install PyQt6 requests semver sympy numpy matplotlib
+pip install PyQt6 requests semver sympy numpy matplotlib scipy
 ```
 
 ### Running the Application

--- a/core/function_props.py
+++ b/core/function_props.py
@@ -118,10 +118,8 @@ class FunctionAnalyzer:
             limit_neg_inf = sp.limit(expr, x, -sp.oo)
             
             if limit_pos_inf.is_finite and limit_neg_inf.is_finite:
-                if limit_pos_inf == limit_neg_inf:
-                    properties['Horizontal Asymptote'] = limit_pos_inf
-                else:
-                    properties['Horizontal Asymptotes'] = {'x→∞': limit_pos_inf, 'x→-∞': limit_neg_inf}
+                # Always use 'Horizontal Asymptotes' (plural) and a consistent dictionary structure
+                properties['Horizontal Asymptotes'] = {'x→∞': limit_pos_inf, 'x→-∞': limit_neg_inf}
             else:
                 properties['Horizontal Asymptotes'] = 'No horizontal asymptotes.'
         except Exception:

--- a/plotting/graph_manager.py
+++ b/plotting/graph_manager.py
@@ -162,11 +162,16 @@ class GraphManager:
                 y_vals = y_func(self.x_vals)
                 self.y_funcs_list.append(y_func)
                 
+                try:
+                    latex_label = sp.latex(expr)
+                except Exception:
+                    latex_label = str(expr) # Fallback to string representation
+                
                 # 绘制函数
                 line, = self.ax.plot(
                     self.x_vals, y_vals, 
                     color=colors[idx % len(colors)],
-                    label=f"${sp.latex(expr)}$"
+                    label=f"${latex_label}$"
                 )
                 self.lines.append(line)
                 


### PR DESCRIPTION
…stness

This commit addresses three issues:

1.  Corrected inconsistent dictionary keys for horizontal asymptotes in `core/function_props.py`. The key 'Horizontal Asymptotes' (plural) is now always used, with a consistent dictionary structure `{'x→∞': val1, 'x→-∞': val2}` for its value when asymptotes exist. This resolves potential errors in code consuming these properties.

2.  Updated `README.md` installation instructions to include `scipy`, which is a necessary dependency listed in `requirements.txt` and used by the application.

3.  Enhanced robustness in `plotting/graph_manager.py` by adding a try-except block around the `sp.latex(expr)` call. If `sp.latex()` fails, it now falls back to using `str(expr)` for the plot label, preventing potential crashes with complex or unsupported expressions.